### PR TITLE
support terraform 0.12.1 and mailgun-go 3.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/phillbaker/terraform-provider-mailgunv3
 go 1.12
 
 require (
-	github.com/hashicorp/terraform v0.11.13
-	github.com/mailgun/mailgun-go/v3 v3.3.2
+	github.com/hashicorp/terraform v0.12.1
+	github.com/mailgun/mailgun-go/v3 v3.5.0
 )

--- a/resource_mailgun_domain.go
+++ b/resource_mailgun_domain.go
@@ -120,8 +120,9 @@ func resourceMailgunDomainCreate(d *schema.ResourceData, meta interface{}) error
 
 	ctx := context.Background()
 
-	_, err := client.CreateDomain(ctx, name, smtpPassword, &mailgun.CreateDomainOptions{
+	_, err := client.CreateDomain(ctx, name, &mailgun.CreateDomainOptions{
 		SpamAction: mailgun.SpamAction(spamAction),
+		Password:   smtpPassword,
 		Wildcard:   wildcard,
 	})
 


### PR DESCRIPTION
these changes appear to be all that is needed to allow this plugin to work with latest terraform and mailgun-go